### PR TITLE
Fix ROS2 entrypoint to source non-interactive bashrc

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -203,7 +203,13 @@ Vagrant.configure("2") do |config|
 
   if [[ "$(uname)" == "Darwin" ]]; then
       NON_ROOT_HOME=/Users/vagrant
-      source ${NON_ROOT_HOME:?err}/.zshrc | exit 1
+
+      if [[ -f "${NON_ROOT_HOME:?err}/.zshrc" ]]; then
+          source "${NON_ROOT_HOME:?err}/.zshrc" || exit 1
+      else
+          echo -e "Unable to find ${NON_ROOT_HOME}/.zshrc indicating that the previous provisioning stage might have fail!" 1>&2
+          exit 1
+      fi
   elif [[ "$(uname)" == "Linux" ]]; then
       NON_ROOT_HOME=/home/vagrant
 

--- a/install.bash
+++ b/install.bash
@@ -185,8 +185,14 @@ function dna::install_dockerized_norlab_project_on_host() {
   dna_bin_dir="${dna_install_dir}/src/bin"
   dna_entrypoint="${dna_bin_dir}/dna"
 
-  # Source minimum required library for install purposes
+  # Source minimum required library for install purposes (phase 1)
   source "${dna_install_dir}/load_repo_main_dotenv.bash"
+
+  # This is required in our case since DNA has multiple git submodule and it might be confusing to
+  # user how to proceed with install.
+  git config --global --add safe.directory "${dna_install_dir}"
+
+  # Source minimum required library for install purposes (phase 2)
   source "${dna_install_dir}/utilities/norlab-shell-script-tools/import_norlab_shell_script_tools_lib.bash"
   source "${dna_install_dir}/src/lib/core/utils/import_dna_lib.bash"
   source "${dna_install_dir}/src/lib/core/utils/setup_host_dna_requirements.bash"

--- a/src/lib/core/docker/container-tools/project_entrypoints/entrypoint_helper.common.bash
+++ b/src/lib/core/docker/container-tools/project_entrypoints/entrypoint_helper.common.bash
@@ -16,6 +16,8 @@ if [[ ${DN_ENTRYPOINT_TRACE_EXECUTION} == true ]]; then
 fi
 
 if [[ -n "${ROS_DISTRO}" ]]; then
+  source /dockerized-norlab/dockerized-norlab-images/container-tools/dn_bashrc_non_interactive.bash
+
   # Should be executed before sourcing ROS2
   if ! ros2 pkg list | grep -q "${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}"; then
       echo "Warning: ${RMW_IMPLEMENTATION} not found, falling back to default RMW"


### PR DESCRIPTION
# Description
Updated the ROS2 entrypoint helper to source `dn_bashrc_non_interactive.bash` for improved non-interactive shell configuration. This change ensures consistent environment variables and paths, enhancing compatibility with existing ROS2 scripts. Adjustments were made to align with project standards.
