### PR TITLE
Improve build script stability and logging clarity  

### DIFF
--- a/src/lib/core/docker/container-tools/dn_project_core.build.patch.bash
+++ b/src/lib/core/docker/container-tools/dn_project_core.build.patch.bash
@@ -19,12 +19,16 @@ function dna::global_install_hack() {
   # ///////////////////////////////////////////////////////////////////////////////////////////////
   # (StandBy) ToDo: maybe transfer to Dockerized-NorLab
   {
+    # Force fix any remaining broken packages
+    export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get update --fix-missing && \
     apt-get install -y "ros-${ROS_DISTRO:?err}-rmw-cyclonedds-cpp" && \
+    dpkg --configure -a && \
+    apt-get install -f && \
     apt-get autoremove -y && \
     apt-get clean ;
-  }|| return 1
+  }|| n2st::print_msg_warning "Be advised, encountered ros-${ROS_DISTRO:?err}-rmw-cyclonedds-cpp install problem. Continue anyway."
   echo "Cyclon DDS performance recommendations (ref https://github.com/ros2/rmw_cyclonedds?tab=readme-ov-file)"
   # shellcheck disable=SC2028
   echo "net.core.rmem_max=8388608\nnet.core.rmem_default=8388608\n" | sudo tee /etc/sysctl.d/60-cyclonedds.conf || return 1

--- a/src/lib/core/execute/build.all.bash
+++ b/src/lib/core/execute/build.all.bash
@@ -145,6 +145,7 @@ function dna::build_services() {
       n2st::print_msg_error "Build error, re-running ${MSG_DIMMED_FORMAT}dna::build_services${MSG_END_FORMAT} one service at the time"
       for idx in "${!services_names[@]}"; do
         if [[ "${services_names[idx]}" == "project-core" ]]; then
+          n2st::print_msg "Building project-core"
           project_core_build_idx=$idx
           dna::excute_compose --file "${the_compose_file}" "${build_docker_flag[@]}" project-core
           project_core_build_exit_code=$?
@@ -156,6 +157,7 @@ function dna::build_services() {
       # Execute docker cmd on all remaining service
       for each in "${services_names[@]}"; do
         if [[ "${each}" != "project-core" ]]; then
+          n2st::print_msg "Building ${each}"
           dna::excute_compose --file "${the_compose_file}" "${build_docker_flag[@]}" "${each}"
           build_exit_code+=("$?")
         else
@@ -187,6 +189,7 @@ function dna::build_services() {
     # Rebuild and push the core image prior to building any other images
     for idx in "${!services_names[@]}"; do
       if [[ "${services_names[idx]}" == "project-core" ]]; then
+        n2st::print_msg "Building project-core"
         project_core_build_idx=$idx
         # Note:
         #   - THIS WORK ON MacOs with buildx builder "docker-container:local-builder-multiarch-virtual"
@@ -205,6 +208,7 @@ function dna::build_services() {
     # Execute docker cmd on all remaining service
     for each in "${services_names[@]}"; do
       if [[ "${each}" != "project-core" ]]; then
+        n2st::print_msg "Building ${each}"
         dna::excute_compose --file "${the_compose_file}" "${build_docker_flag[@]}" "${each}"
         build_exit_code+=("$?")
       else

--- a/src/lib/core/utils/execute_compose.bash
+++ b/src/lib/core/utils/execute_compose.bash
@@ -195,8 +195,8 @@ Exiting now!
 
   # (Priority) ToDo: validate >> changes to next bloc ↓↓ does'nt break TeamCity build
   local docker_cmd_str="${MSG_DIMMED_FORMAT}docker compose --file ${compose_path}/${the_compose_file} ${docker_command_w_flags[*]}${MSG_END_FORMAT}"
-  n2st::teamcity_service_msg_blockOpened "Execute ${docker_cmd_str[*]}"
-  #n2st::print_msg "Execute ${docker_cmd_str}\n"
+  n2st::print_msg "Execute ${docker_cmd_str}\n"
+  n2st::teamcity_service_msg_blockOpened "$ docker compose --file ${compose_path}/${the_compose_file} ${docker_command_w_flags[*]}"
 
   # Refactor using "n2st::show_and_execute_docker" (See ref NMO-575)
   docker compose --file "${compose_path}/${the_compose_file}" "${docker_command_w_flags[@]}"


### PR DESCRIPTION
# Description
This pull request includes the following improvements:
- Enhanced handling of package installations in the build script by using `dpkg --configure -a` and `apt-get install -f`. Added a warning message to notify users about ROS package installation issues, aiming for improved build stability.
- Introduced detailed logging for service builds in `build.all.bash`, leveraging `n2st::print_msg` for informative messages. Improved the formatting and logging of Docker commands for alignment with TeamCity service messages.
