### PR TITLE
Set NVIDIA GPU defaults to none in docker-compose

### DIFF
--- a/src/lib/core/docker/Dockerfile.project-core-final
+++ b/src/lib/core/docker/Dockerfile.project-core-final
@@ -21,7 +21,22 @@ RUN <<EOF
     source /dn_project_core_finalize.bash \
       || n2st::print_msg_error_and_exit "Failed dn_project_core_finalize.bash!"
 
-    # Cleanup buidl script
+    # ....Project directories ownership............................................................
+    n2st::print_msg "Set project directories ownership"
+    {
+      chown -R $(id -u ${DN_PROJECT_USER:?err}):$(id -g ${DN_PROJECT_USER}) ${DN_PROJECT_USER_HOME:?err}
+      chown -R $(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER}) ${DN_PROJECT_PATH:?err}
+      chown -R $(id -u ${DN_PROJECT_USER}):$(id -g ${DN_PROJECT_USER}) ${DN_DEV_WORKSPACE:?err}
+    } || {
+      # Collect debugg information on faillure
+      pwd
+      tree -agu
+      tree -agu ${DN_PROJECT_USER_HOME}
+      tree -agu ${DN_DEV_WORKSPACE}
+      exit 1
+    }
+
+    # ....Cleanup buidl script.....................................................................
     rm -f /dn_project_core_init.bash
     rm -f /dna-lib-container-tools/dn_project_core.setup.bash
     rm -f /dna-lib-container-tools/dn_project_core.build.aarch_aware_build_ros.bash

--- a/src/lib/core/docker/docker-compose.project.run.ci-tests.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.ci-tests.yaml
@@ -15,9 +15,9 @@ services:
       DN_ACTIVATE_POWERLINE_PROMT: false
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       QT_X11_NO_MITSHM: 1
       XAUTHORITY: /tmp/.docker.xauth

--- a/src/lib/core/docker/docker-compose.project.run.ci-tests.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.ci-tests.yaml
@@ -17,7 +17,7 @@ services:
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       QT_X11_NO_MITSHM: 1
       XAUTHORITY: /tmp/.docker.xauth

--- a/src/lib/core/docker/docker-compose.project.run.jetson.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.jetson.yaml
@@ -18,9 +18,9 @@ services:
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
       DN_ACTIVATE_POWERLINE_PROMT: ${DN_ACTIVATE_POWERLINE_PROMT:-false}
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       DISPLAY: ${DISPLAY:-":0"}
       QT_X11_NO_MITSHM: 1

--- a/src/lib/core/docker/docker-compose.project.run.jetson.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.jetson.yaml
@@ -20,7 +20,7 @@ services:
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       DISPLAY: ${DISPLAY:-":0"}
       QT_X11_NO_MITSHM: 1

--- a/src/lib/core/docker/docker-compose.project.run.linux-x86.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.linux-x86.yaml
@@ -39,9 +39,9 @@ services:
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
       DN_ACTIVATE_POWERLINE_PROMT: ${DN_ACTIVATE_POWERLINE_PROMT:-false}
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
-      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-all}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-all}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       DISPLAY: ${DISPLAY:-":0"}
       QT_X11_NO_MITSHM: 1

--- a/src/lib/core/docker/docker-compose.project.run.linux-x86.yaml
+++ b/src/lib/core/docker/docker-compose.project.run.linux-x86.yaml
@@ -41,7 +41,7 @@ services:
       IS_TEAMCITY_RUN: ${IS_TEAMCITY_RUN:-false}
       NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES:-void}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
-      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-""}
+      NVIDIA_DRIVER_CAPABILITIES: ${NVIDIA_DRIVER_CAPABILITIES:-}
       #     see https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
       DISPLAY: ${DISPLAY:-":0"}
       QT_X11_NO_MITSHM: 1

--- a/src/lib/core/execute/run.slurm.bash
+++ b/src/lib/core/execute/run.slurm.bash
@@ -69,6 +69,7 @@ function dna::run_slurm_teardown_callback() {
   local compose_path="${DNA_ROOT:?err}/src/lib/core/docker"
   local the_compose_file=docker-compose.project.run.slurm.yaml
   local running_container_ids
+  source "${DNA_LIB_PATH:?err}/core/utils/load_super_project_config.bash"
   running_container_ids=$(docker compose -f "${compose_path}/${the_compose_file}" ps --quiet --all --orphans=false)
   if [[ -n ${running_container_ids} ]]; then
     for each_id in "${running_container_ids[@]}"; do
@@ -253,11 +254,13 @@ function dna::run_slurm() {
       n2st::print_msg "Execute docker ${MSG_DIMMED_FORMAT}${docker_log[*]}${MSG_END_FORMAT}"
       # Note: Operator "2>&1 |" redirect both stdin and stderr (portable version of "|&")
       docker "${docker_log[@]}" "${container_id}" 2>&1 | tee "${SUPER_PROJECT_ROOT:?err}/${log_path}/${log_name}.log"
+      exit_code=$?
+    else
+      echo && n2st::print_msg "Execute ${MSG_DIMMED_FORMAT}docker wait${MSG_END_FORMAT}"
+      docker wait "${container_id}" # Required if docker logs is skipped
+      #docker compose "${compose_flags[@]}" wait "${the_service}" # Required if docker logs is skipped
+      exit_code=$?
     fi
-
-    echo && n2st::print_msg "Execute ${MSG_DIMMED_FORMAT}docker wait${MSG_END_FORMAT}"
-    docker wait "${container_id}" # Required if docker logs is skipped
-    exit_code=$?
   fi
 
   # ....Teardown...................................................................................

--- a/src/lib/core/utils/cuda_tools.bash
+++ b/src/lib/core/utils/cuda_tools.bash
@@ -196,7 +196,7 @@ function dna::configure_gpu_capabilities() {
   fi
 
   # ....Begin......................................................................................
-  if [[ $NVIDIA_VISIBLE_DEVICES == void ]]; then
+  if [[ -z $NVIDIA_VISIBLE_DEVICES ]] || [[ $NVIDIA_VISIBLE_DEVICES == void ]]; then
     n2st::print_msg "No nvidia gpu support expected by user"
     NVIDIA_VISIBLE_DEVICES=void
     NVIDIA_DRIVER_CAPABILITIES=""

--- a/src/lib/template/.dockerized_norlab/configuration/.env
+++ b/src/lib/template/.dockerized_norlab/configuration/.env
@@ -12,35 +12,36 @@
 
 # ....GPU..........................................................................................
 # Reference: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html
-NVIDIA_VISIBLE_DEVICES=all
-# Options: "all", "none", "void", gpu UUID e.g., "GPU-fef8089b or gpu indexes list e.g., "0,1,2"
 
-NVIDIA_DRIVER_CAPABILITIES=all
-# Options: "all" or a list of comma-separated driver's name e.g., "compute,utility"
+# Nvidia visible devices options: "all", "none", "void", gpu UUID e.g., "GPU-fef8089b or gpu indexes list e.g., "0,1,2"
+#NVIDIA_VISIBLE_DEVICES=all
+
+# Nvidia driver capabilities options: "all" or a list of comma-separated driver's name e.g., "compute,utility"
 # Available driver: compute, compat32, graphics, utility, video or display
+#NVIDIA_DRIVER_CAPABILITIES=all
 
 # ....ROS..........................................................................................
-ROS_DOMAIN_ID=1
+#ROS_DOMAIN_ID=1
 
 # Enable ROS2 log collouring
-RCUTILS_COLORIZED_OUTPUT=1
+#RCUTILS_COLORIZED_OUTPUT=1
 
-RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-# Option: rmw_fastrtps_cpp, rmw_cyclonedds_cpp
+# rmw implementation options: rmw_fastrtps_cpp, rmw_cyclonedds_cpp
+#RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-DDS_NETWORK_INTERFACE=eth0
-CYCLONEDDS_URI="<CycloneDDS><Domain><General><NetworkInterface>${DDS_NETWORK_INTERFACE:?err}</></></></>"
+#DDS_NETWORK_INTERFACE=eth0
+#CYCLONEDDS_URI="<CycloneDDS><Domain><General><NetworkInterface>${DDS_NETWORK_INTERFACE:?err}</></></></>"
 # Fix for warning "ros2: using network interface eth0 (udp/169.254.205.89) selected
 #  arbitrarily from: eth0, wlan0, docker0".
 # Solution ref: https://answers.ros.org/question/375360/multiple-network-interfaces-with-rmw_cyclonedds_cpp/
 
 # ....Python.......................................................................................
-PYTHONUNBUFFERED=1
-PYCHARM_DEBUG=1
+#PYTHONUNBUFFERED=1
+#PYCHARM_DEBUG=1
 #PYTEST_DEBUG=1
 
 # ....Hydra........................................................................................
-HYDRA_FULL_ERROR=1
+#HYDRA_FULL_ERROR=1
 
 # Set omegaconf full error backtrace
-OC_CAUSE=1
+#OC_CAUSE=1

--- a/src/lib/template/slurm_jobs/slurm_job.hydra_template.bash
+++ b/src/lib/template/slurm_jobs/slurm_job.hydra_template.bash
@@ -58,7 +58,7 @@ hydra_flags+=("launcher/example_app.py")
 # ....Debug flags..................................................................................
 dna_run_slurm_flags+=(--register-hydra-dry-run-flag "+new_key='fake-value'")
 
-#dna_run_slurm_flags+=("--skip-core-force-rebuild")
+dna_run_slurm_flags+=("--skip-core-force-rebuild")
 #dna_run_slurm_flags+=("--dry-run")
 #hydra_flags+=("--cfg" "all")
 

--- a/src/lib/template/slurm_jobs/slurm_job.hydra_template_hparam_optim.bash
+++ b/src/lib/template/slurm_jobs/slurm_job.hydra_template_hparam_optim.bash
@@ -16,12 +16,12 @@
 # =================================================================================================
 declare -x SJOB_ID
 declare -a dna_run_slurm_flags=()
-declare -a python_arguments=()
+declare -a hydra_flags=()
 
 # ====Setup========================================================================================
 # ....Custom setup (optional)......................................................................
 function dna::job_setup_callback() {
-  # Add any instruction that should be executed before 'dna run slurm' command
+  # TODO: Add any instruction that should be executed before 'dna run slurm' command
   :
 }
 
@@ -41,14 +41,26 @@ SJOB_ID="default"
 # Note: Recommend opening an issue tracker task (e.g., YouTrack, GitHub issue, Trello)
 #  and use its issue ID as an SJOB_ID.
 
-# ....Python module................................................................................
+# ....Hydra app module.............................................................................
 # TODO: Set python module to launch
-python_arguments+=("launcher/example.py")
+hydra_flags+=("launcher/example_app_hparm_optim.py")
 # Note: assume container workdir is `<super-project>/src/`
 
+# ....Optional hydra flags.........................................................................
+# --config-path,-cp : Overrides the config_path specified in hydra.main(). (absolute or relative)
+# --config-name,-cn : Overrides the config_name specified in hydra.main()
+# --config-dir,-cd : Adds an additional config dir to the config search path
+
+#hydra_flags+=("--config-path=")
+#hydra_flags+=("--config-dir=")
+#hydra_flags+=("--config-name=")
+
 # ....Debug flags..................................................................................
+dna_run_slurm_flags+=(--register-hydra-dry-run-flag "+new_key='fake-value'")
+
 dna_run_slurm_flags+=("--skip-core-force-rebuild")
 #dna_run_slurm_flags+=("--dry-run")
+#hydra_flags+=("--cfg" "all")
 
 # ====DNA internal=================================================================================
 dna_run_slurm_flags+=("--log-name" "$(basename -s .bash $0)")
@@ -59,4 +71,6 @@ dna::job_setup_callback
 trap dna::job_teardown_callback EXIT
 
 # ====Launch slurm job=============================================================================
-dna run slurm "${SJOB_ID:?err}" "${dna_run_slurm_flags[@]}" "${python_arguments[@]}"
+dna version --all
+dna run slurm "${SJOB_ID:?err}" "${dna_run_slurm_flags[@]}" "${hydra_flags[@]}"
+

--- a/src/lib/template/src/launcher/configs/example_app_hparm_optim.yaml
+++ b/src/lib/template/src/launcher/configs/example_app_hparm_optim.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 
 defaults:
-  - pytorch_check
+  - example_app
   - hparam_optimization_base
   - _self_
 

--- a/tests/tests_bats/test_cuda_tools.bats
+++ b/tests/tests_bats/test_cuda_tools.bats
@@ -678,6 +678,27 @@ EOF
   assert_equal "${DN_DOCKER_RUNTIME}" "runc"
 }
 
+@test "dna::configure_gpu_capabilities › user did not set NVIDIA_VISIBLE_DEVICES › expect void settings" {
+  # Mock the required functions
+  function dna::fetch_host_nvidia_gpu_architecture() {
+    echo "sm_75"
+  }
+  export -f dna::fetch_host_nvidia_gpu_architecture
+
+  # Set initial environment with user preference
+  unset NVIDIA_VISIBLE_DEVICES
+  unset NVIDIA_DRIVER_CAPABILITIES
+  #export DN_DOCKER_RUNTIME="runc"
+
+  # Execute the function directly (not in subshell)
+  dna::configure_gpu_capabilities "linux/x86" "/tmp" "docker-compose.yml" "gpu-service"
+
+  # Verify environment variables respect user setting
+  assert_equal "${NVIDIA_VISIBLE_DEVICES}" "void"
+  assert_equal "${NVIDIA_DRIVER_CAPABILITIES}" ""
+  assert_equal "${DN_DOCKER_RUNTIME}" "runc"
+}
+
 @test "dna::configure_gpu_capabilities › torch compatibility test fails › expect failure" {
   # Mock the required functions
   function dna::fetch_host_nvidia_gpu_architecture() {


### PR DESCRIPTION
# Description
This update sets the default values for `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` in docker-compose files to "void" and an empty string, respectively. Environment variables related to Nvidia, ROS, and Python are commented out in the `.dockerized_norlab/configuration/.env` template files to allow user customization. Additionally, detailed comments have been added to enhance clarity in Nvidia-related configurations.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_