### PR TITLE
Adjust auto-update logic and improve temporary file management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 **/artifact/**/*
 **/slurm_jobs_logs/*.log
 /.env.dockerized-norlab-project.local
-/.dna_last_update_check
 
 # ....Dev required.................................................................................
 /utilities/tmp/dockerized-norlab-project-mock/

--- a/src/bin/dna
+++ b/src/bin/dna
@@ -58,7 +58,7 @@ test -d "${DNA_LIB_PATH:?err}" || { echo -e "${dna_error_prefix} library load er
 # ::::Auto-update functions:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 function dna::should_run_daily_update() {
     # Check if daily update should run based on timestamp
-    local timestamp_file="${DNA_ROOT}/.dna_last_update_check"
+    local timestamp_file="/tmp/.dna_last_update_check"
     local current_date
     local last_check_date
     
@@ -76,10 +76,12 @@ function dna::should_run_daily_update() {
 
 function dna::update_timestamp() {
     # Update the timestamp file with current date
-    local timestamp_file="${DNA_ROOT}/.dna_last_update_check"
+    local timestamp_file="/tmp/.dna_last_update_check"
     local current_date
     
     current_date=$(date +%Y-%m-%d)
+#    sudo touch "${timestamp_file}"
+#    sudo chmod 664 "${timestamp_file}"
     echo "${current_date}" > "${timestamp_file}"
 }
 

--- a/src/lib/commands/update.bash
+++ b/src/lib/commands/update.bash
@@ -126,6 +126,7 @@ function dna::update_toggle_auto_update_setting() {
         fi
     else
         # Create new file
+        sudo touch "${env_file}"
         echo "DNA_AUTO_UPDATE=${new_value}" > "${env_file}"
     fi
 
@@ -180,7 +181,7 @@ function dna::update_command() {
 
     # Handle --toggle-auto flag
     if [[ "${toggle_auto}" == true ]]; then
-        dna::update_toggle_auto_update_setting
+        dna::update_toggle_auto_update_setting || n2st::print_msg_error_and_exit "Unable to toggle auto-update! Might require sudo."
         return 0
     fi
 

--- a/tests/tests_bats/test_dna.bats
+++ b/tests/tests_bats/test_dna.bats
@@ -245,7 +245,7 @@ setup() {
 teardown() {
   bats_print_run_env_variable_on_error
   unset MOCK_DNA_AUTO_UPDATE
-  rm -f "${MOCK_DNA_DIR}/.dna_last_update_check"
+  rm -f "/tmp/.dna_last_update_check"
 }
 
 teardown_file() {
@@ -556,7 +556,7 @@ teardown_file() {
   # Test case: When dna is called with a regular command like 'init', auto-update should run
   export MOCK_DNA_AUTO_UPDATE=true
 
-  echo "0000-00-00" > "${MOCK_DNA_DIR}/.dna_last_update_check"
+  echo "0000-00-00" > "/tmp/.dna_last_update_check"
   run bash "${MOCK_DNA_DIR}"/src/bin/dna init
 
   # Should succeed
@@ -566,15 +566,15 @@ teardown_file() {
   assert_output --partial "dna::run_daily_auto_update >> mock dna::update_command --yes"
   # Should also call the init function
   assert_output --partial "Mock dna::init_command called with args:"
-  assert_file_exist "${MOCK_DNA_DIR}/.dna_last_update_check"
-  assert_file_contains "${MOCK_DNA_DIR}/.dna_last_update_check" "$(date +%Y-%m-%d)"
-  #cat "${MOCK_DNA_DIR}/.dna_last_update_check" >&3
+  assert_file_exist "/tmp/.dna_last_update_check"
+  assert_file_contains "/tmp/.dna_last_update_check" "$(date +%Y-%m-%d)"
+  #cat "/tmp/.dna_last_update_check" >&3
 }
 
 @test "dna auto-update › expect auto-update to be skipped if executed twice on same day" {
   # Test case: When dna is called more than once in a day, auto-update should be skipped
   export MOCK_DNA_AUTO_UPDATE=true
-  date +%Y-%m-%d > "${MOCK_DNA_DIR}/.dna_last_update_check"
+  date +%Y-%m-%d > "/tmp/.dna_last_update_check"
 
   run bash "${MOCK_DNA_DIR}"/src/bin/dna init
 
@@ -585,9 +585,9 @@ teardown_file() {
   refute_output --partial "dna::run_daily_auto_update >> mock dna::update_command --yes"
   # Should also call the init function
   assert_output --partial "Mock dna::init_command called with args:"
-  assert_file_exist "${MOCK_DNA_DIR}/.dna_last_update_check"
-  assert_file_contains "${MOCK_DNA_DIR}/.dna_last_update_check" "$(date +%Y-%m-%d)"
-  #cat "${MOCK_DNA_DIR}/.dna_last_update_check" >&3
+  assert_file_exist "/tmp/.dna_last_update_check"
+  assert_file_contains "/tmp/.dna_last_update_check" "$(date +%Y-%m-%d)"
+  #cat "/tmp/.dna_last_update_check" >&3
 }
 
 @test "dna version command › expect auto-update to be skipped" {


### PR DESCRIPTION
# Description
This pull request refines the auto-update functionality by:

- Relocating the `.dna_last_update_check` file to `/tmp/` for better temporary file management and avoiding pollution of the local repository.
- Introducing improved error-handling logic when toggling auto-update to provide robust user feedback.
- Removing `.dna_last_update_check` from `.gitignore` since it is now stored outside the tracked repository.

These changes ensure a cleaner repository setup and enhance the user experience related to auto-update configuration.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_