### PR TITLE
Fix slurm dry run test stability

### DIFF
--- a/src/lib/core/execute/project_validate.slurm.bash
+++ b/src/lib/core/execute/project_validate.slurm.bash
@@ -162,13 +162,14 @@ function dna::project_validate_slurm() {
 
   n2st::print_msg "Completed build in dry-run mode tests"
 
-  # ....Dry-run SLURM/Mamba jobs.....................................................................
+  # ....Dry-run SLURM/Mamba jobs on native aarch.....................................................
   n2st::print_formated_script_header "Dry-run slurm job" "${line_format}" "${line_style}"
   pushd "$(pwd)" >/dev/null || exit 1
 
+  # Execute slurm joc dry-run tests
   slurm_job_file_name=()
   for each_file_path in "${SUPER_PROJECT_ROOT:?err}"/"${slurm_script_job_path}"/slurm_job.*.bash ; do
-    each_file_name="$(basename $each_file_path)"
+    each_file_name="$(basename "${each_file_path}")"
     slurm_job_file_name+=("$each_file_name")
   done
 

--- a/tests/tests_dryrun_and_tests_scripts/test_project_validate.slurm.bash
+++ b/tests/tests_dryrun_and_tests_scripts/test_project_validate.slurm.bash
@@ -12,11 +12,15 @@ function dna::test_teardown_callback() {
 }
 trap dna::test_teardown_callback EXIT
 
-cd "${DNA_MOCK_SUPER_PROJECT_ROOT:?err}" || exit 1
-
 # ====begin========================================================================================
+
+# Re-build slurm image (required on TC to prevent ownership error related to agent switching)
+cd "${DNA_MOCK_SUPER_PROJECT_ROOT:?err}" || exit 1
+bash "${DNA_LIB_EXEC_PATH:?err}"/build.all.bash --service-names project-slurm -- --no-cache
+
 # Execute project validate slurm script
 # Note: the "--include-multiarch" flag affect only the dry-run config check, not the slurm job check
+cd "${DNA_MOCK_SUPER_PROJECT_ROOT:?err}" || exit 1
 bash "${DNA_LIB_EXEC_PATH:?err}"/project_validate.slurm.bash --include-multiarch "slurm_jobs"
 
 ## ....Teardown.....................................................................................


### PR DESCRIPTION
# Description
This pull request addresses a stability issue in the slurm job dry-run tests. Specifically:
- Rebuild logic for the slurm image is added to prevent ownership errors caused by agent switching in the test environment.
- Minor corrections in variable usage within the slurm job dry-run tests are made.

# Checklist:

### Code related
- [x] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [x] I have commented hard-to-understand code 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

 ## Note for repository admins
 ### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_