### PR TITLE
Add DN_HOST and DN_HOST_GPU_ARCHITECTURE environment variables

### DIFF
--- a/src/lib/core/docker/docker-compose.run.ci-tests.yaml
+++ b/src/lib/core/docker/docker-compose.run.ci-tests.yaml
@@ -24,7 +24,6 @@ services:
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
       # DN_HOST: 'linux/x86'
       DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
-      DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
       DN_ACTIVATE_POWERLINE_PROMT: false
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}

--- a/src/lib/core/docker/docker-compose.run.ci-tests.yaml
+++ b/src/lib/core/docker/docker-compose.run.ci-tests.yaml
@@ -23,6 +23,8 @@ services:
       # -----------
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
       # DN_HOST: 'linux/x86'
+      DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+      DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
       DN_ACTIVATE_POWERLINE_PROMT: false
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}

--- a/src/lib/core/docker/docker-compose.run.ci-tests.yaml
+++ b/src/lib/core/docker/docker-compose.run.ci-tests.yaml
@@ -22,8 +22,8 @@ services:
       DISPLAY: "" # Keep unset
       # -----------
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
-      # DN_HOST: 'linux/x86'
-      DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+      DN_HOST: 'linux/x86'
+      # DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
       DN_ACTIVATE_POWERLINE_PROMT: false
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}

--- a/src/lib/core/docker/docker-compose.run.darwin.yaml
+++ b/src/lib/core/docker/docker-compose.run.darwin.yaml
@@ -10,6 +10,8 @@ x-darwin-common: &darwin-common
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'darwin/arm64'
+    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.darwin.yaml
+++ b/src/lib/core/docker/docker-compose.run.darwin.yaml
@@ -11,7 +11,6 @@ x-darwin-common: &darwin-common
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'darwin/arm64'
     DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
-    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.darwin.yaml
+++ b/src/lib/core/docker/docker-compose.run.darwin.yaml
@@ -9,8 +9,8 @@ x-darwin-common: &darwin-common
   container_name: ${DN_CONTAINER_NAME:?err}
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
-    # DN_HOST: 'darwin/arm64'
-    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST: 'darwin/arm64'
+    # DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.jetson.yaml
+++ b/src/lib/core/docker/docker-compose.run.jetson.yaml
@@ -9,8 +9,8 @@ x-jetson-common: &jetson-common
   container_name: ${DN_CONTAINER_NAME:?err}
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
-    # DN_HOST: 'l4t/arm64'
-    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST: 'l4t/arm64'
+    # DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.jetson.yaml
+++ b/src/lib/core/docker/docker-compose.run.jetson.yaml
@@ -10,6 +10,8 @@ x-jetson-common: &jetson-common
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'l4t/arm64'
+    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.jetson.yaml
+++ b/src/lib/core/docker/docker-compose.run.jetson.yaml
@@ -11,7 +11,6 @@ x-jetson-common: &jetson-common
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'l4t/arm64'
     DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
-    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}

--- a/src/lib/core/docker/docker-compose.run.linux-x86.yaml
+++ b/src/lib/core/docker/docker-compose.run.linux-x86.yaml
@@ -33,7 +33,6 @@ x-linux-x86-common: &linux-x86-common
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'linux/x86'
     DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
-    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
     DN_ACTIVATE_POWERLINE_PROMT: ${DN_ACTIVATE_POWERLINE_PROMT:-false}

--- a/src/lib/core/docker/docker-compose.run.linux-x86.yaml
+++ b/src/lib/core/docker/docker-compose.run.linux-x86.yaml
@@ -31,8 +31,8 @@ x-linux-x86-common: &linux-x86-common
   container_name: ${DN_CONTAINER_NAME:?err}
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
-    # DN_HOST: 'linux/x86'
-    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST: 'linux/x86'
+    # DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
     DN_ACTIVATE_POWERLINE_PROMT: ${DN_ACTIVATE_POWERLINE_PROMT:-false}

--- a/src/lib/core/docker/docker-compose.run.linux-x86.yaml
+++ b/src/lib/core/docker/docker-compose.run.linux-x86.yaml
@@ -32,6 +32,8 @@ x-linux-x86-common: &linux-x86-common
   environment:
     # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
     # DN_HOST: 'linux/x86'
+    DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+    DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
     DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}
     DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}
     DN_ACTIVATE_POWERLINE_PROMT: ${DN_ACTIVATE_POWERLINE_PROMT:-false}

--- a/src/lib/core/docker/docker-compose.run.slurm.yaml
+++ b/src/lib/core/docker/docker-compose.run.slurm.yaml
@@ -26,7 +26,6 @@ services:
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
       # DN_HOST: 'linux/x86'
       DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
-      DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
       DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}-slurm${SJOB_ID}
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}

--- a/src/lib/core/docker/docker-compose.run.slurm.yaml
+++ b/src/lib/core/docker/docker-compose.run.slurm.yaml
@@ -24,8 +24,8 @@ services:
       # (☕minor) ToDo: validate deleting env var IS_SLURM_RUN -> its not used
       IS_SLURM_RUN: ${IS_SLURM_RUN:-false}
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
-      # DN_HOST: 'linux/x86'
-      DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+      DN_HOST: 'linux/x86'
+      # DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
       DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}-slurm${SJOB_ID}
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}

--- a/src/lib/core/docker/docker-compose.run.slurm.yaml
+++ b/src/lib/core/docker/docker-compose.run.slurm.yaml
@@ -25,6 +25,8 @@ services:
       IS_SLURM_RUN: ${IS_SLURM_RUN:-false}
       # (NICE TO HAVE) ToDo: add logic to auto set DN_HOST at runtime if its relevant (ref task NMO-669)
       # DN_HOST: 'linux/x86'
+      DN_HOST: ${IMAGE_ARCH_AND_OS:?err}
+      DN_HOST_GPU_ARCHITECTURE: ${DN_HOST_GPU_ARCHITECTURE:?err}
       DN_PROJECT_USER: ${DN_PROJECT_USER:?err}
       DN_CONTAINER_NAME: ${DN_CONTAINER_NAME:?err}-slurm${SJOB_ID}
       DN_ENTRYPOINT_TRACE_EXECUTION: ${DN_ENTRYPOINT_TRACE_EXECUTION:-false}


### PR DESCRIPTION
# Description
This pull request introduces two new environment variables: `DN_HOST` and `DN_HOST_GPU_ARCHITECTURE`. These additions enhance Docker Compose configuration flexibility and improve runtime debugging by making these variables explicitly accessible. Updates have also been applied to relevant bash scripts.

# Checklist:

### Code related
- [ ] I have made corresponding changes to the documentation (i.e.: function/class, script header, README.md)
- [ ] I have commented hard-to-understand code 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes (Check `tests/README.md` for local testing procedure) 
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org) specification. See `commit_msg_reference.md` in the repository root for details

### PR creation related 
- [x] My pull request `base ref` branch is set to the `dev` branch (the _build-system_ won't be triggered otherwise) 
- [x] My pull request branch is up-to-date with the `dev` branch (the _build-system_ will reject it otherwise)

## Note for repository admins
### Release PR related
- Only repository admins have the privilege to `push/merge` on the default branch (ie: `main`) and the `release` branch.
- Keep PR in `draft` mode until all the release reviewers are ready to push the release. 
- Once a PR from `release` -> `main` branch is created (not in draft mode), it triggers the _build-system_ test
- On merge to the `main` branch, it triggers the _semantic-release automation_