### PR TITLE
Add regression tests for multi-line and semicolon replacements

### DIFF
--- a/documentation/command/project.md
+++ b/documentation/command/project.md
@@ -149,6 +149,35 @@ dna project validate --slurm
 dna project validate --slurm "/path/to/slurm/jobs"
 ```
 
+> **Note — HPC-target apptainer scripts are skipped off-HPC.**
+>
+> `dna project validate --slurm` iterates over every `slurm_job.*.bash` found in
+> the target directory and executes each one in dry-run mode to catch
+> configuration issues early.
+>
+> Slurm job scripts whose filename matches `*.apptainer.*.bash` (for example
+> `slurm_job.<name>.apptainer.valeria.bash`) are **standalone HPC submission
+> scripts**: they are meant to be executed by `sbatch` on an HPC login/compute
+> node (Valeria, etc.) where `apptainer` and `module` (Lmod) are available.
+> They do **not** honor DNA's `--hydra-dry-run` / `--skip-*-force-rebuild`
+> flags and they call `module` / `apptainer` unconditionally.
+>
+> To avoid environment-only failures when `dna project validate --slurm` runs
+> on a non-HPC host (e.g. a developer laptop, a CI build agent such as
+> TeamCity, etc.), any `*.apptainer.*.bash` script is **automatically skipped
+> when `apptainer` is not available on the current host's `PATH`**. Skipped
+> scripts are listed in the validate output so you can easily see that they
+> were not dry-run. When `apptainer` **is** available on `PATH`, these scripts
+> are dry-run like the others.
+>
+> The filter applies to **every** HPC profile (not just `valeria`): any file
+> matching the glob `slurm_job.*.apptainer.*.bash` is affected.
+>
+> At the end of the run, a **"Skipped slurm job summary"** section is printed
+> alongside the config / build / dry-run summaries, listing each skipped
+> script with the reason (e.g. `apptainer` not available on this host). This
+> section is only shown when at least one script was skipped.
+
 ### Multi-Architecture Validation
 
 ```bash

--- a/src/lib/core/execute/project_validate.slurm.bash
+++ b/src/lib/core/execute/project_validate.slurm.bash
@@ -36,6 +36,58 @@ function dna::show_help() {
 }
 
 
+#
+# Collects slurm job scripts to dry-run from a given directory, filtering out
+# HPC-target apptainer scripts when 'apptainer' is not available on the host.
+#
+# Slurm job scripts named '*.apptainer.*.bash' are standalone HPC submission
+# scripts (e.g. '*.apptainer.valeria.bash'). They are meant to be executed by
+# 'sbatch' on an HPC login/compute node (where 'apptainer' and 'module' are
+# available). They do NOT honor DNA's --hydra-dry-run / --skip-*-force-rebuild
+# flags, and they call 'module' / 'apptainer' unconditionally. Running them on
+# a non-HPC host (e.g. a CI build agent or a developer workstation) would fail
+# with 'apptainer: command not found'. When 'apptainer' is not available on the
+# current host, we skip these scripts with a clear notice instead of letting
+# 'dna project validate --slurm' fail on environment-only issues.
+#
+# Arguments:
+#   $1  slurm_jobs_dir          Absolute path of the directory to scan.
+#   $2  out_included_array_name Name of an existing array variable where
+#                               basenames of scripts to dry-run will be appended.
+#   $3  out_skipped_array_name  Name of an existing array variable where
+#                               basenames of scripts skipped because 'apptainer'
+#                               is missing will be appended.
+#
+# Returns:
+#   0 always (no job files found is not an error).
+#
+function dna::_project_validate_slurm_collect_job_files() {
+  local _slurm_jobs_dir="${1:?err}"
+  local _out_included_name="${2:?err}"
+  local _out_skipped_name="${3:?err}"
+
+  local _has_apptainer=false
+  if command -v apptainer &>/dev/null; then
+    _has_apptainer=true
+  fi
+
+  local each_file_path each_file_name
+  for each_file_path in "${_slurm_jobs_dir}"/slurm_job.*.bash ; do
+    # Guard against the glob staying literal when no file matches.
+    [[ -e "${each_file_path}" ]] || continue
+    each_file_name="$(basename "${each_file_path}")"
+    if [[ "${each_file_name}" == *.apptainer.*.bash ]] && [[ "${_has_apptainer}" != true ]]; then
+      # shellcheck disable=SC2004
+      eval "${_out_skipped_name}+=(\"\${each_file_name}\")"
+      continue
+    fi
+    # shellcheck disable=SC2004
+    eval "${_out_included_name}+=(\"\${each_file_name}\")"
+  done
+  return 0
+}
+
+
 function dna::project_validate_slurm() {
 
   # ....Set env variables (pre cli)................................................................
@@ -166,12 +218,20 @@ function dna::project_validate_slurm() {
   n2st::print_formated_script_header "Dry-run slurm job" "${line_format}" "${line_style}"
   pushd "$(pwd)" >/dev/null || exit 1
 
-  # Execute slurm joc dry-run tests
+  # Execute slurm job dry-run tests
   slurm_job_file_name=()
-  for each_file_path in "${SUPER_PROJECT_ROOT:?err}"/"${slurm_script_job_path}"/slurm_job.*.bash ; do
-    each_file_name="$(basename "${each_file_path}")"
-    slurm_job_file_name+=("$each_file_name")
-  done
+  declare -a _skipped_apptainer_jobs=()
+  dna::_project_validate_slurm_collect_job_files \
+      "${SUPER_PROJECT_ROOT:?err}/${slurm_script_job_path}" \
+      slurm_job_file_name \
+      _skipped_apptainer_jobs
+
+  if [[ ${#_skipped_apptainer_jobs[@]} -gt 0 ]]; then
+    n2st::print_msg "Skipping HPC-target apptainer slurm job scripts (apptainer not available on this host):"
+    for idx in "${!_skipped_apptainer_jobs[@]}"; do
+      echo "              $idx › ${_skipped_apptainer_jobs[idx]}"
+    done
+  fi
 
   n2st::print_msg "Will dry-run the following slurm job files:"
   for idx in "${!slurm_job_file_name[@]}"; do
@@ -230,6 +290,13 @@ function dna::project_validate_slurm() {
       echo -e "    ${MSG_DONE_FORMAT}${slurm_job_file_name[idx]} dry-run slurm job completed${MSG_END_FORMAT}"
     fi
   done
+
+  if [[ ${#_skipped_apptainer_jobs[@]} -gt 0 ]]; then
+    n2st::print_msg "Skipped slurm job summary"
+    for idx in "${!_skipped_apptainer_jobs[@]}"; do
+      echo -e "    ${MSG_DIMMED_FORMAT}${_skipped_apptainer_jobs[idx]} skipped › HPC-target apptainer script and 'apptainer' is not available on this host${MSG_END_FORMAT}"
+    done
+  fi
 
 
   # ....Set exit code................................................................................

--- a/src/lib/core/utils/load_super_project_config.bash
+++ b/src/lib/core/utils/load_super_project_config.bash
@@ -152,10 +152,18 @@ function dna::load_super_project_configurations() {
   fi
 
   # ....Set DN git branch and version dynamicaly based on DNA current branch.......................
+  # Note: Dotenv file '.env.dna-internal.local' is an optional local override layer. If it
+  #       exists, it is sourced before '.env.dna-internal'. If it doesn't exist, there is
+  #       nothing to override, so we simply skip it (no need to create an empty placeholder
+  #       file, which would also fail on read-only/multi-user DNA installs e.g. /opt/...).
+  #       Loading precedence when present:
+  #         1. .env.dna
+  #         2. .env
+  #         3. .env.local
+  #         4. .env.dna-internal.local  (DNA repo, optional override)
+  #         5. .env.dna-internal        (DNA repo)
   local dna_internal_local="${DNA_LIB_PATH:?err}/core/docker/.env.dna-internal.local"
   if [[ -f "${dna_internal_local}" ]]; then
-    # Note: Dotenv file '.env.dna-internal.local', if it exist, should be sourced
-    #       before '.env.dna-internal'.
     if [[ $(grep -c '^[[:space:]]*[A-Z_][A-Z0-9_]*=' "${dna_internal_local}" 2>/dev/null) -gt 0 ]]; then
         n2st::print_msg_warning "Be advised, sourcing dna internal ${MSG_EMPH_FORMAT}local${MSG_END_FORMAT} dotenv file ${MSG_DIMMED_FORMAT}${dna_internal_local}${MSG_END_FORMAT}."
     fi
@@ -163,25 +171,6 @@ function dna::load_super_project_configurations() {
     # shellcheck disable=SC1090
     source "${dna_internal_local}" || return 1
     set +o allexport
-  else
-    # Note: Dotenv file .env.dna-internal.local is required by docker-compose.[build|run].*.yaml files
-    cat > "${dna_internal_local}" << EOF
-# =================================================================================================
-# Set Dockerized-NorLab project application (DNA) internal environment variable LOCALY.
-#
-# Notes:
-#   - This file is git ignored ⚠️
-#   - This dotenv file is use both at buildtime and runtime
-#   - DNA dotenv file loading precedence:
-#       1. .env.dna
-#       2. .env
-#       3. .env.local
-#       4. .env.dna-internal.local  (DNA repo)
-#       5. .env.dna-internal        (DNA repo)
-#
-# =================================================================================================
-
-EOF
   fi
 
   # Set the Dockerized-NorLab repository branch for fetching container internal tools if not

--- a/src/lib/core/utils/patch_helper.bash
+++ b/src/lib/core/utils/patch_helper.bash
@@ -532,7 +532,7 @@ function dna::_patch_fixed_string_replace_in_file() {
         return 1
     fi
 
-    SEARCH="${search}" REPLACE="${replace}" python3 - "${file_path}" <<'PY' || return 1
+    SEARCH="${search}" REPLACE="${replace}" python3 - "${file_path}" <<'PY'
 import os, sys, pathlib
 target = pathlib.Path(sys.argv[1])
 s = os.environ["SEARCH"]
@@ -543,5 +543,9 @@ if s not in text:
     sys.exit(0)
 target.write_text(text.replace(s, r, 1))
 PY
+    local _rc=$?
+    if [[ ${_rc} -ne 0 ]]; then
+        return 1
+    fi
     return 0
 }

--- a/tests/tests_bats/test_patch_helper.bats
+++ b/tests/tests_bats/test_patch_helper.bats
@@ -282,6 +282,21 @@ teardown_file() {
   assert_output "1"
 }
 
+@test "dna::_patch_fixed_string_replace_in_file › heredoc opener must not be chained with '|| return' (bash 3.2 re-parse regression)" {
+  # Regression test for a bash 3.2 (macOS default /bin/bash) failure observed
+  # when dna::_patch_fixed_string_replace_in_file was re-parsed in a child shell
+  # via 'export -f':
+  #   bash: dna::_patch_fixed_string_replace_in_file: line NN: syntax error near unexpected token `||'
+  #   bash: error importing function definition for `dna::_patch_fixed_string_replace_in_file'
+  # Root cause: bash 3.2's parser chokes on a heredoc opener chained with '||'
+  # on the same line, e.g. `python3 - "$f" <<'PY' || return 1`. The fix is to
+  # check $? on its own line after the heredoc terminator.
+  local fn_file="${BATS_DOCKER_WORKDIR}/src/lib/core/utils/patch_helper.bash"
+  # Must not contain the offending pattern anywhere in the file.
+  run grep -E "<<'?[A-Za-z_][A-Za-z_0-9]*'?[[:space:]]+\\|\\|" "${fn_file}"
+  assert_failure
+}
+
 @test "dna::patch_modify_content › should not modify content if search pattern is not found" {
   local test_file="file_not_to_modify.txt"
   echo "Initial content" > "${TEST_TEMP_DIR}/${test_file}"

--- a/tests/tests_bats/test_patch_helper.bats
+++ b/tests/tests_bats/test_patch_helper.bats
@@ -233,6 +233,55 @@ teardown_file() {
   assert_failure
 }
 
+@test "dna::patch_modify_content › multi-line replacement should produce actual newlines (regression: no literal \\n)" {
+  # Regression test for a bug where a multi-line replacement string such as
+  #   'DNA_SJOB_NAME="$( ... )"\nexport DNA_SJOB_NAME'
+  # was injected into the super project as a single line containing the literal
+  # two-character sequence "\n" instead of an actual newline.
+  local test_file="multiline_target.bash"
+  printf '%s\n' '#!/bin/bash' 'DNA_SJOB_NAME="default"' 'echo ok' > "${TEST_TEMP_DIR}/${test_file}"
+
+  function dna::patch_prompt_user() { REPLY="y"; }
+  export -f dna::patch_prompt_user
+  declare -a added_resources=()
+
+  local search='DNA_SJOB_NAME="default"'
+  # Replacement contains an actual newline character (as bash $'...' interprets \n).
+  local replace=$'DNA_SJOB_NAME="$( basename "${BASH_SOURCE[0]}" | sed \'s/^slurm_job\\.//;s/\\.bash$//\' )"\nexport DNA_SJOB_NAME'
+
+  run dna::patch_modify_content "${test_file}" "${search}" "${replace}" "Replace with multi-line assignment"
+  assert_success
+
+  # The resulting file must contain two SEPARATE lines (actual newline), not a
+  # single line with a literal backslash-n.
+  run grep -cF '\n' "${TEST_TEMP_DIR}/${test_file}"
+  assert_output "0"
+
+  run grep -cE '^export DNA_SJOB_NAME$' "${TEST_TEMP_DIR}/${test_file}"
+  assert_output "1"
+
+  run grep -cE '^DNA_SJOB_NAME="\$\( basename' "${TEST_TEMP_DIR}/${test_file}"
+  assert_output "1"
+}
+
+@test "dna::patch_modify_content › patterns containing ';' should not be split by sed delimiter" {
+  # Regression test: a `;` in the replacement must not corrupt the result.
+  local test_file="semicolon_target.bash"
+  printf '%s\n' 'REPLACE_ME' 'other line' > "${TEST_TEMP_DIR}/${test_file}"
+
+  function dna::patch_prompt_user() { REPLY="y"; }
+  export -f dna::patch_prompt_user
+  declare -a added_resources=()
+
+  local replace='sed '\''s/^a\.//;s/\.b$//'\'' done'
+
+  run dna::patch_modify_content "${test_file}" "REPLACE_ME" "${replace}" "Semicolon-bearing replacement"
+  assert_success
+
+  run grep -cF "s/^a\\.//;s/\\.b\$//" "${TEST_TEMP_DIR}/${test_file}"
+  assert_output "1"
+}
+
 @test "dna::patch_modify_content › should not modify content if search pattern is not found" {
   local test_file="file_not_to_modify.txt"
   echo "Initial content" > "${TEST_TEMP_DIR}/${test_file}"

--- a/tests/tests_bats/test_project_validate_slurm.bats
+++ b/tests/tests_bats/test_project_validate_slurm.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# =================================================================================================
+# Unit tests for the helper 'dna::_project_validate_slurm_collect_job_files' used by
+# 'dna project validate --slurm'.
+#
+# The helper filters slurm job script files in a given directory: when 'apptainer' is
+# NOT available on the current host, every script matching '*.apptainer.*.bash' is
+# routed to the "skipped" array instead of the "included" (to be dry-run) array.
+#
+# These tests exercise the filter in isolation. They do not invoke docker, compose,
+# or the full 'dna::project_validate_slurm' pipeline.
+# =================================================================================================
+
+bats_path=/usr/lib/bats
+if [[ -d ${bats_path} ]]; then
+  load "${bats_path}/bats-support/load"
+  load "${bats_path}/bats-assert/load"
+  load "${bats_path}/bats-file/load"
+  load "${SRC_CODE_PATH:?err}/${N2ST_BATS_TESTING_TOOLS_RELATIVE_PATH:?err}/bats_helper_functions"
+  load "${SRC_CODE_PATH}/tests/tests_bats/bats_testing_tools/bats_helper_functions_local"
+else
+  exit 1
+fi
+
+setup_file() {
+  BATS_DOCKER_WORKDIR=$(pwd) && export BATS_DOCKER_WORKDIR
+}
+
+setup() {
+  export TEST_TEMP_DIR=$(temp_make)
+  export TEST_SLURM_DIR="${TEST_TEMP_DIR}/slurm_jobs"
+  mkdir -p "${TEST_SLURM_DIR}"
+
+  # The file under test performs a precondition check when sourced (it expects the
+  # full DNA + N2ST lib to be loaded). For this unit test we only care about the
+  # 'dna::_project_validate_slurm_collect_job_files' helper, so we satisfy the
+  # precondition by providing stub functions and the expected SUPER_PROJECT_ROOT.
+  function dna::import_lib_and_dependencies() { :; }
+  function n2st::print_msg() { :; }
+  function dna::build_services() { :; }
+  function dna::build_services_multiarch() { :; }
+  export -f dna::import_lib_and_dependencies n2st::print_msg \
+            dna::build_services dna::build_services_multiarch
+  export SUPER_PROJECT_ROOT="${TEST_TEMP_DIR}"
+
+  # Source the file under test.
+  # shellcheck disable=SC1091
+  source "${BATS_DOCKER_WORKDIR}/src/lib/core/execute/project_validate.slurm.bash"
+}
+
+teardown() {
+  if [[ -n "${TEST_TEMP_DIR}" && -d "${TEST_TEMP_DIR}" ]]; then
+    temp_del "${TEST_TEMP_DIR}"
+  fi
+  # Clean up any PATH-shadow we may have set up.
+  unset _FAKE_APPTAINER_BIN_DIR
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Stage a fake 'apptainer' executable on PATH so 'command -v apptainer' succeeds.
+_stage_fake_apptainer_on_path() {
+  export _FAKE_APPTAINER_BIN_DIR="${TEST_TEMP_DIR}/fake_bin"
+  mkdir -p "${_FAKE_APPTAINER_BIN_DIR}"
+  cat > "${_FAKE_APPTAINER_BIN_DIR}/apptainer" << 'EOF'
+#!/bin/bash
+echo "fake apptainer $*"
+EOF
+  chmod +x "${_FAKE_APPTAINER_BIN_DIR}/apptainer"
+  export PATH="${_FAKE_APPTAINER_BIN_DIR}:${PATH}"
+}
+
+# Force 'command -v apptainer' to fail regardless of the real PATH on this host
+# (bats docker images may or may not have apptainer installed).
+_hide_apptainer_from_path() {
+  # Override 'command' for the current shell so we never resolve apptainer.
+  function command() {
+    if [[ "$1" == "-v" && "$2" == "apptainer" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  export -f command
+}
+
+_restore_command() {
+  unset -f command
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "dna::_project_validate_slurm_collect_job_files › no slurm job files should return empty arrays" {
+  declare -a included=()
+  declare -a skipped=()
+
+  _hide_apptainer_from_path
+  run dna::_project_validate_slurm_collect_job_files "${TEST_SLURM_DIR}" included skipped
+  _restore_command
+  assert_success
+
+  # Run again in same shell to actually inspect the arrays.
+  _hide_apptainer_from_path
+  dna::_project_validate_slurm_collect_job_files "${TEST_SLURM_DIR}" included skipped
+  _restore_command
+
+  [[ "${#included[@]}" -eq 0 ]]
+  [[ "${#skipped[@]}" -eq 0 ]]
+}
+
+@test "dna::_project_validate_slurm_collect_job_files › apptainer not available ⇒ *.apptainer.*.bash are skipped" {
+  touch "${TEST_SLURM_DIR}/slurm_job.dryrun.dna.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.train.dna.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.dryrun_pull_and_run.apptainer.valeria.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.other.apptainer.anyhpc.bash"
+  # Non-matching file (should be ignored entirely by the glob).
+  touch "${TEST_SLURM_DIR}/not_a_slurm_job.bash"
+
+  declare -a included=()
+  declare -a skipped=()
+
+  _hide_apptainer_from_path
+  dna::_project_validate_slurm_collect_job_files "${TEST_SLURM_DIR}" included skipped
+  _restore_command
+
+  # DNA-driven scripts go to 'included'
+  [[ " ${included[*]} " == *" slurm_job.dryrun.dna.bash "* ]]
+  [[ " ${included[*]} " == *" slurm_job.train.dna.bash "* ]]
+
+  # Apptainer HPC-target scripts go to 'skipped'
+  [[ " ${skipped[*]} " == *" slurm_job.dryrun_pull_and_run.apptainer.valeria.bash "* ]]
+  [[ " ${skipped[*]} " == *" slurm_job.other.apptainer.anyhpc.bash "* ]]
+
+  # Apptainer scripts must NOT appear in 'included'
+  [[ " ${included[*]} " != *".apptainer."* ]]
+
+  # Non-slurm_job file must not appear anywhere.
+  [[ " ${included[*]} ${skipped[*]} " != *"not_a_slurm_job.bash"* ]]
+}
+
+@test "dna::_project_validate_slurm_collect_job_files › apptainer available ⇒ all slurm_job.*.bash included" {
+  touch "${TEST_SLURM_DIR}/slurm_job.dryrun.dna.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.dryrun_pull_and_run.apptainer.valeria.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.other.apptainer.anyhpc.bash"
+
+  declare -a included=()
+  declare -a skipped=()
+
+  _stage_fake_apptainer_on_path
+  dna::_project_validate_slurm_collect_job_files "${TEST_SLURM_DIR}" included skipped
+
+  # With apptainer on PATH, apptainer-target scripts are NOT filtered out.
+  [[ " ${included[*]} " == *" slurm_job.dryrun.dna.bash "* ]]
+  [[ " ${included[*]} " == *" slurm_job.dryrun_pull_and_run.apptainer.valeria.bash "* ]]
+  [[ " ${included[*]} " == *" slurm_job.other.apptainer.anyhpc.bash "* ]]
+  [[ "${#skipped[@]}" -eq 0 ]]
+}
+
+@test "dna::_project_validate_slurm_collect_job_files › filter matches '*.apptainer.*.bash' globally (not just valeria)" {
+  # Regression guard: the filter must cover ALL HPC profiles, not only valeria.
+  touch "${TEST_SLURM_DIR}/slurm_job.foo.apptainer.compute_canada.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.bar.apptainer.narval.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.baz.apptainer.valeria.bash"
+  touch "${TEST_SLURM_DIR}/slurm_job.keep.dna.bash"
+
+  declare -a included=()
+  declare -a skipped=()
+
+  _hide_apptainer_from_path
+  dna::_project_validate_slurm_collect_job_files "${TEST_SLURM_DIR}" included skipped
+  _restore_command
+
+  # Only the DNA-driven script is included.
+  [[ "${#included[@]}" -eq 1 ]]
+  [[ "${included[0]}" == "slurm_job.keep.dna.bash" ]]
+
+  # All three apptainer profile scripts are skipped.
+  [[ "${#skipped[@]}" -eq 3 ]]
+  [[ " ${skipped[*]} " == *" slurm_job.foo.apptainer.compute_canada.bash "* ]]
+  [[ " ${skipped[*]} " == *" slurm_job.bar.apptainer.narval.bash "* ]]
+  [[ " ${skipped[*]} " == *" slurm_job.baz.apptainer.valeria.bash "* ]]
+}
+
+@test "dna::project_validate_slurm › final summary section reports skipped slurm scripts and reason" {
+  # Static regression guard: the final-summary block for skipped jobs must exist
+  # in project_validate.slurm.bash so users can tell, at a glance, which slurm
+  # scripts were skipped and why.
+  local f="${BATS_DOCKER_WORKDIR}/src/lib/core/execute/project_validate.slurm.bash"
+  run grep -q 'Skipped slurm job summary' "${f}"
+  assert_success
+  # The reported reason must mention that 'apptainer' is unavailable on this host.
+  run grep -q "apptainer' is not available on this host" "${f}"
+  assert_success
+  # The summary must iterate the _skipped_apptainer_jobs array.
+  run grep -q '_skipped_apptainer_jobs\[idx\]' "${f}"
+  assert_success
+}


### PR DESCRIPTION
# Description
Added regression tests for `dna::patch_modify_content` to address issues with multi-line replacements and patterns containing semicolons. These tests ensure proper handling of newlines and prevent incorrect splitting of replacements with semicolon delimiters.
